### PR TITLE
i#1558: Use new behavior of CMP0043 in drgui

### DIFF
--- a/ext/drgui/CMakeLists.txt
+++ b/ext/drgui/CMakeLists.txt
@@ -51,8 +51,6 @@ else () # Qt5 and CMake 3.2+
 
   include(../../make/policies.cmake NO_POLICY_SCOPE)
 
-  cmake_policy(SET CMP0043 OLD)
-
   # Set ouput_dir since drgui_qt is the only executable extension
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/ext/${INSTALL_BIN}")
 


### PR DESCRIPTION
Old CMP0043 policy instructs CMake to respect
COMPILE_DEFINITIONS_<CONFIG> target properties and apply the specified definitions when building in <CONFIG> mode.

Searching through our repository with COMPILE_DEFINITIONS_ shows no result, suggesting we don't really depend on it anymore. As the policy is completely in CMake 4.x, failing DynamoRIO build, let's switch to the new behavior.

Fixes #1558